### PR TITLE
Add a translator version that returns null if it can't translate.

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -42,6 +42,15 @@ const translateErrorCode = function translateErrorCode(errCode) {
   return errStringMap[errCode] || errCode;
 };
 
+/**
+ * Translates a provided Binaris error code into a more explicit and
+ * descriptive string representation, or returns null if no better
+ * representation exists.
+ */
+const maybeTranslateErrorCode = function maybeTranslateErrorCode(errCode) {
+  return errStringMap[errCode] || null;
+};
+
 module.exports = {
-  translateErrorCode,
+  translateErrorCode, maybeTranslateErrorCode,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris-pickle",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Binaris utility and glue code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows an old client that gets an error code to get by with the
server-provided message.

Only ran `eslint`.

For binaris/binaris#410.