### PR TITLE
Remove index.js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-const { translateErrorCode } = require('./errors');
-
-module.exports = {
-  translateErrorCode,
-};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "binaris-pickle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Binaris utility and glue code",
-  "main": "index.js",
+  "main": "errors.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint -c .eslintrc.js .",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
It's just a forgettable redirection.  `pickle` currently handles
errors, nothing else.